### PR TITLE
Fix ping issue

### DIFF
--- a/hbmqtt/mqtt/protocol/client_handler.py
+++ b/hbmqtt/mqtt/protocol/client_handler.py
@@ -95,8 +95,8 @@ class ClientProtocolHandler(ProtocolHandler):
 
     def handle_write_timeout(self):
         try:
-            self.logger.debug("Scheduling Ping")
             if not self._ping_task:
+                self.logger.debug("Scheduling Ping")
                 self._ping_task = ensure_future(self.mqtt_ping())
         except BaseException as be:
             self.logger.debug("Exception ignored in ping task: %r" % be)
@@ -167,6 +167,8 @@ class ClientProtocolHandler(ProtocolHandler):
         self._pingresp_waiter = futures.Future(loop=self._loop)
         resp = yield from self._pingresp_queue.get()
         self._pingresp_waiter = None
+        if self._ping_task:
+            self._ping_task = None
         return resp
 
     @asyncio.coroutine


### PR DESCRIPTION
While testing hbmqtt with the ``test.mosquitto.org`` public server and my own local installation of the Mosquitto broker showed that the hbmqtt ``MQTTClient`` would consistently disconnect and then reconnect. 

This problem appears to be caused by the ``_ping_task`` attribute never being cleared. This prevents any further Ping messages being sent, which eventually triggers a disconnection and then a subsequent reconnect.

The modification in this pull request resolves the problem, which leaves the client connected to the server and sending a ping message at the keep alive interval.