### PR TITLE
Install default yaml files in scripts directory

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include scripts *.yaml

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
     url="https://github.com/beerfactory/hbmqtt",
     license='MIT',
     packages=find_packages(exclude=['tests']),
+    include_package_data=True,
     platforms='all',
     install_requires=[
         'transitions==0.2.5',
@@ -54,8 +55,5 @@ setup(
             'hbmqtt_pub = scripts.pub_script:main',
             'hbmqtt_sub = scripts.sub_script:main',
         ]
-    },
-    data_files = [
-        ('scripts', ['scripts/default_broker.yaml', 'scripts/default_client.yaml'])
-    ]
+    }
 )

--- a/setup.py
+++ b/setup.py
@@ -54,5 +54,8 @@ setup(
             'hbmqtt_pub = scripts.pub_script:main',
             'hbmqtt_sub = scripts.sub_script:main',
         ]
-    }
+    },
+    data_files = [
+        ('scripts', ['scripts/default_broker.yaml', 'scripts/default_client.yaml'])
+    ]
 )


### PR DESCRIPTION
I found that when installing the hbmqtt package using setup.py, the auto created scripts hbmqtt, hbmqtt_pub & hbmqtt_sub throw an error that the default yaml filesdo not exist in the scripts directory. This small change to the setup.py will copy default_broker.yaml & default_client.yaml to the python env scripts directory.