### PR TITLE
accept boolean as config argument for "ssl"

### DIFF
--- a/hbmqtt/broker.py
+++ b/hbmqtt/broker.py
@@ -237,7 +237,13 @@ class Broker:
 
                     # SSL Context
                     sc = None
-                    if 'ssl' in listener and listener['ssl'].upper() == 'ON':
+
+                    # accept string "on" / "off" or boolean
+                    ssl_active = listener.get('ssl', False)
+                    if isinstance(ssl_active, str):
+                        ssl_active = ssl_active.upper() == 'ON'
+
+                    if ssl_active:
                         try:
                             sc = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
                             sc.load_cert_chain(listener['certfile'], listener['keyfile'])


### PR DESCRIPTION
the config flag "ssl" must be a string (on / off).  I like to suggest it should also accept a boolean.

The example uses a yaml config.  Since parsing "on" [0] in yaml returns a boolean using the example config results in an error.

[0] http://yaml.org/type/bool.html