### PR TITLE
Switch : and @ in URL examples

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -67,9 +67,9 @@ Here are some examples of URL:
 
     mqtt://localhost
     mqtt://localhost:1884
-    mqtt://user@password:localhost
+    mqtt://user:password@localhost
     ws://test.mosquitto.org
-    wss://user@password:localhost
+    wss://user:password@localhost
 
 .. _MQTT URL scheme: https://github.com/mqtt/mqtt.github.io/wiki/URI-Scheme
 


### PR DESCRIPTION
I think the : and @ tokens are backwards in two of the examples.

This patch should correct the order.