### PR TITLE
release PluginManager._fired_events if they are done

### DIFF
--- a/hbmqtt/plugins/manager.py
+++ b/hbmqtt/plugins/manager.py
@@ -142,6 +142,7 @@ class PluginManager:
             if tasks:
                 yield from asyncio.wait(tasks, loop=self._loop)
         else:
+            self._fired_events = [e for e in self._fired_events if not e.done()]
             self._fired_events.extend(tasks)
 
     @asyncio.coroutine


### PR DESCRIPTION
_fire_events are only released when a plugin is closed. A long-running application will see memory usage keep growing.

I'd propose to release _fire_events that are done whenever more events are going to be added.