### PR TITLE
Include all files in the PyPI releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
-hbmqtt/__pycache__
+*.egg-info
 *.pyc
-
 .idea/hbmqtt.iml
+.tox/
+__pycache__
+build/
+dist/
+tests/plugins/test.db

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,17 @@
-recursive-include scripts *.yaml
+include *.rst
+include *.txt
 include license.txt
+include samples/passwd
+include tests/plugins/passwd
+include tox.ini
+
+recursive-include docs *.css
+recursive-include docs *.html
+recursive-include docs *.py
+recursive-include docs *.rst
+recursive-include docs Makefile
+recursive-include samples *.crt
+recursive-include samples *.py
+recursive-include scripts *.yaml
+recursive-include tests *.crt
+recursive-include tests *.py

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,8 @@ envlist =
     py344,
     py35,
     coverage,
-    #flake8
+    #flake8,
+    check-manifest
 
 [testenv]
 deps =
@@ -24,3 +25,6 @@ deps =
     coverage
     -rrequirements.txt
 
+[testenv:check-manifest]
+deps = check-manifest
+commands = check-manifest


### PR DESCRIPTION
- Included tests, examples, etc in MANIFEST.in.
- Made git ignore files that should not be included in the package.
- Added tox test environment which runs check-manifest to validate the
  MANIFEST.in file.

Downstreams like Debian prefer the PyPI packages to include everything
from the Git repo, especially changelogs and test suites. To make the
installation with pip as lightweight as possible, it is encouraged to
build and upload Python wheels in addition to the sdist tarball.

The test suite currently included in the PyPI release is incomplete and thus
fails when building the Debian package. With this PR merged and released
the Debian package should be able to run the test suite automatically when
built.