### PR TITLE
Run test on all supported Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,8 @@ python:
   - "3.6"
   - "nightly"
 install:
-  - pip install -r requirements.txt
   - pip install tox-travis
   - pip install coveralls
-# command to run tests
 script:
   - tox
 after_success: coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 sudo: false
 language: python
 python:
+  - "3.4"
   - "3.5"
-  - "3.6-dev"
+  - "3.6"
   - "nightly"
 install:
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 sudo: false
 language: python
 python:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-transitions
-websockets==3.3.0
-passlib
-docopt
-pyyaml

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist =
     py34,
     py35,
+    py36,
     coverage,
     #flake8,
     check-manifest

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py344,
+    py34,
     py35,
     coverage,
     #flake8,

--- a/tox.ini
+++ b/tox.ini
@@ -8,9 +8,7 @@ envlist =
     check-manifest
 
 [testenv]
-deps =
-    nose
-    -rrequirements.txt
+deps = nose
 commands = nosetests
 
 [testenv:flake8]
@@ -22,9 +20,7 @@ commands =
     python -m coverage erase
     python -m coverage run --branch --source=hbmqtt -m unittest
     python -m coverage report
-deps =
-    coverage
-    -rrequirements.txt
+deps = coverage
 
 [testenv:check-manifest]
 deps = check-manifest


### PR DESCRIPTION
This modifies the Tox and Travis CI setup to run tests on all supported Python versions locally with `tox` and at Travis CI.

As the `requirements.txt` contained the same set of dependencies as `setup.py`, which is used by both Tox and Travis through Tox, it was redundant and was removed.

See commit messages for details.