### PR TITLE
fixed Test 'test_client_connect_clean_session_false' 

### DIFF
--- a/hbmqtt/mqtt/connect.py
+++ b/hbmqtt/mqtt/connect.py
@@ -171,10 +171,9 @@ class ConnectPayload(MQTTPayload):
         if (payload.client_id is None or payload.client_id == ""):
             # A Server MAY allow a Client to supply a ClientId that has a length of zero bytes
             # [MQTT-3.1.3-6]
-            payload.client_id=gen_client_id();
+            payload.client_id = gen_client_id()
             # indicator to trow exception in case CLEAN_SESSION_FLAG is set to False
-            payload.client_id_is_random=True;
- 
+            payload.client_id_is_random = True
 
         # Read will topic, username and password
         if variable_header.will_flag:
@@ -306,7 +305,7 @@ class ConnectPacket(MQTTPacket):
         return self.payload.client_id_is_random
 
     @client_id_is_random.setter
-    def client_id_is_random(self, client_id_is_random:bool):
+    def client_id_is_random(self, client_id_is_random: bool):
         self.payload.client_id_is_random = client_id_is_random
 
     @property

--- a/hbmqtt/mqtt/connect.py
+++ b/hbmqtt/mqtt/connect.py
@@ -136,11 +136,17 @@ class ConnectVariableHeader(MQTTVariableHeader):
 class ConnectPayload(MQTTPayload):
 
     __slots__ = (
-        'client_id', 'will_topic', 'will_message', 'username', 'password'
+        'client_id',
+        'will_topic',
+        'will_message',
+        'username',
+        'password',
+        'client_id_is_random',
     )
 
     def __init__(self, client_id=None, will_topic=None, will_message=None, username=None, password=None):
         super().__init__()
+        self.client_id_is_random = False
         self.client_id = client_id
         self.will_topic = will_topic
         self.will_message = will_message
@@ -163,7 +169,12 @@ class ConnectPayload(MQTTPayload):
             payload.client_id = None
 
         if (payload.client_id is None or payload.client_id == ""):
+            # A Server MAY allow a Client to supply a ClientId that has a length of zero bytes
+            # [MQTT-3.1.3-6]
             payload.client_id=gen_client_id();
+            # indicator to trow exception in case CLEAN_SESSION_FLAG is set to False
+            payload.client_id_is_random=True;
+ 
 
         # Read will topic, username and password
         if variable_header.will_flag:
@@ -289,6 +300,14 @@ class ConnectPacket(MQTTPacket):
     @client_id.setter
     def client_id(self, client_id):
         self.payload.client_id = client_id
+
+    @property
+    def client_id_is_random(self) -> bool:
+        return self.payload.client_id_is_random
+
+    @client_id_is_random.setter
+    def client_id_is_random(self, client_id_is_random:bool):
+        self.payload.client_id_is_random = client_id_is_random
 
     @property
     def will_topic(self):

--- a/tests/mqtt/test_connect.py
+++ b/tests/mqtt/test_connect.py
@@ -61,7 +61,7 @@ class ConnectPacketTest(unittest.TestCase):
         data = b'\x10\x0a\x00\x04MQTT\x04\xce\x00\x00'
         stream = BufferReader(data)
         message = self.loop.run_until_complete(ConnectPacket.from_stream(stream))
-        self.assertIs(message.payload.client_id, None)
+        self.assertIsNot(message.payload.client_id, None)
 
     def test_decode_fail_miss_willtopic(self):
         data = b'\x10\x16\x00\x04MQTT\x04\xce\x00\x00\x00\x0a0123456789'

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -39,7 +39,7 @@ test_config = {
     'listeners': {
         'default': {
             'type': 'tcp',
-            'bind': 'localhost:1883',
+            'bind': '127.0.0.1:1883',
             'max_connections': 10
         },
     },
@@ -102,7 +102,7 @@ class BrokerTest(unittest.TestCase):
                 yield from broker.start()
                 self.assertTrue(broker.transitions.is_started())
                 client = MQTTClient()
-                ret = yield from client.connect('mqtt://localhost/')
+                ret = yield from client.connect('mqtt://127.0.0.1/')
                 self.assertEqual(ret, 0)
                 self.assertIn(client.session.client_id, broker._sessions)
                 yield from client.disconnect()
@@ -133,7 +133,7 @@ class BrokerTest(unittest.TestCase):
                 self.assertTrue(broker.transitions.is_started())
 
                 conn_reader, conn_writer = \
-                    yield from asyncio.open_connection('localhost', 1883, loop=self.loop)
+                    yield from asyncio.open_connection('127.0.0.1', 1883, loop=self.loop)
                 reader = StreamReaderAdapter(conn_reader)
                 writer = StreamWriterAdapter(conn_writer)
 
@@ -181,7 +181,7 @@ class BrokerTest(unittest.TestCase):
                 client = MQTTClient(client_id="", config={'auto_reconnect': False})
                 return_code = None
                 try:
-                    yield from client.connect('mqtt://localhost/', cleansession=False)
+                    yield from client.connect('mqtt://127.0.0.1/', cleansession=False)
                 except ConnectException as ce:
                     return_code = ce.return_code
                 self.assertEqual(return_code, 0x02)
@@ -207,7 +207,7 @@ class BrokerTest(unittest.TestCase):
                 yield from broker.start()
                 self.assertTrue(broker.transitions.is_started())
                 client = MQTTClient()
-                ret = yield from client.connect('mqtt://localhost/')
+                ret = yield from client.connect('mqtt://127.0.0.1/')
                 self.assertEqual(ret, 0)
                 yield from client.subscribe([('/topic', QOS_0)])
 
@@ -245,7 +245,7 @@ class BrokerTest(unittest.TestCase):
                 yield from broker.start()
                 self.assertTrue(broker.transitions.is_started())
                 client = MQTTClient()
-                ret = yield from client.connect('mqtt://localhost/')
+                ret = yield from client.connect('mqtt://127.0.0.1/')
                 self.assertEqual(ret, 0)
                 yield from client.subscribe([('/topic', QOS_0)])
 
@@ -289,7 +289,7 @@ class BrokerTest(unittest.TestCase):
                 yield from broker.start()
                 self.assertTrue(broker.transitions.is_started())
                 client = MQTTClient()
-                ret = yield from client.connect('mqtt://localhost/')
+                ret = yield from client.connect('mqtt://127.0.0.1/')
                 self.assertEqual(ret, 0)
                 yield from client.subscribe([('/topic', QOS_0)])
 
@@ -335,7 +335,7 @@ class BrokerTest(unittest.TestCase):
                 yield from broker.start()
                 self.assertTrue(broker.transitions.is_started())
                 pub_client = MQTTClient()
-                ret = yield from pub_client.connect('mqtt://localhost/')
+                ret = yield from pub_client.connect('mqtt://127.0.0.1/')
                 self.assertEqual(ret, 0)
 
                 ret_message = yield from pub_client.publish('/topic', b'data', QOS_0)
@@ -370,7 +370,7 @@ class BrokerTest(unittest.TestCase):
                 self.assertTrue(broker.transitions.is_started())
 
                 conn_reader, conn_writer = \
-                    yield from asyncio.open_connection('localhost', 1883, loop=self.loop)
+                    yield from asyncio.open_connection('127.0.0.1', 1883, loop=self.loop)
                 reader = StreamReaderAdapter(conn_reader)
                 writer = StreamWriterAdapter(conn_writer)
 
@@ -421,7 +421,7 @@ class BrokerTest(unittest.TestCase):
                 yield from broker.start()
                 self.assertTrue(broker.transitions.is_started())
                 pub_client = MQTTClient()
-                ret = yield from pub_client.connect('mqtt://localhost/')
+                ret = yield from pub_client.connect('mqtt://127.0.0.1/')
                 self.assertEqual(ret, 0)
 
                 yield from pub_client.publish('/+', b'data', QOS_0)
@@ -449,7 +449,7 @@ class BrokerTest(unittest.TestCase):
                 yield from broker.start()
                 self.assertTrue(broker.transitions.is_started())
                 pub_client = MQTTClient()
-                ret = yield from pub_client.connect('mqtt://localhost/')
+                ret = yield from pub_client.connect('mqtt://127.0.0.1/')
                 self.assertEqual(ret, 0)
 
                 ret_message = yield from pub_client.publish('/topic', bytearray(b'\x99' * 256 * 1024), QOS_2)
@@ -484,7 +484,7 @@ class BrokerTest(unittest.TestCase):
                 self.assertTrue(broker.transitions.is_started())
 
                 pub_client = MQTTClient()
-                ret = yield from pub_client.connect('mqtt://localhost/')
+                ret = yield from pub_client.connect('mqtt://127.0.0.1/')
                 self.assertEqual(ret, 0)
                 yield from pub_client.publish('/topic', b'data', QOS_0, retain=True)
                 yield from pub_client.disconnect()
@@ -516,7 +516,7 @@ class BrokerTest(unittest.TestCase):
                 self.assertTrue(broker.transitions.is_started())
 
                 pub_client = MQTTClient()
-                ret = yield from pub_client.connect('mqtt://localhost/')
+                ret = yield from pub_client.connect('mqtt://127.0.0.1/')
                 self.assertEqual(ret, 0)
                 yield from pub_client.publish('/topic', b'', QOS_0, retain=True)
                 yield from pub_client.disconnect()
@@ -542,7 +542,7 @@ class BrokerTest(unittest.TestCase):
                 yield from broker.start()
                 self.assertTrue(broker.transitions.is_started())
                 sub_client = MQTTClient()
-                yield from sub_client.connect('mqtt://localhost')
+                yield from sub_client.connect('mqtt://127.0.0.1')
                 ret = yield from sub_client.subscribe([('/qos0', QOS_0), ('/qos1', QOS_1), ('/qos2', QOS_2)])
                 self.assertEqual(ret, [QOS_0, QOS_1, QOS_2])
 
@@ -578,7 +578,7 @@ class BrokerTest(unittest.TestCase):
                 yield from broker.start()
                 self.assertTrue(broker.transitions.is_started())
                 sub_client = MQTTClient()
-                yield from sub_client.connect('mqtt://localhost')
+                yield from sub_client.connect('mqtt://127.0.0.1')
                 ret = yield from sub_client.subscribe(
                     [('+', QOS_0), ('+/tennis/#', QOS_0), ('sport+', QOS_0), ('sport/+/player1', QOS_0)])
                 self.assertEqual(ret, [QOS_0, QOS_0, 0x80, QOS_0])
@@ -606,7 +606,7 @@ class BrokerTest(unittest.TestCase):
                 yield from broker.start()
                 self.assertTrue(broker.transitions.is_started())
                 sub_client = MQTTClient()
-                yield from sub_client.connect('mqtt://localhost')
+                yield from sub_client.connect('mqtt://127.0.0.1')
                 ret = yield from sub_client.subscribe([('#', QOS_0)])
                 self.assertEqual(ret, [QOS_0])
 
@@ -644,7 +644,7 @@ class BrokerTest(unittest.TestCase):
                 yield from broker.start()
                 self.assertTrue(broker.transitions.is_started())
                 sub_client = MQTTClient()
-                yield from sub_client.connect('mqtt://localhost')
+                yield from sub_client.connect('mqtt://127.0.0.1')
                 ret = yield from sub_client.subscribe([('+/monitor/Clients', QOS_0)])
                 self.assertEqual(ret, [QOS_0])
 
@@ -682,7 +682,7 @@ class BrokerTest(unittest.TestCase):
                 yield from broker.start()
                 self.assertTrue(broker.transitions.is_started())
                 sub_client = MQTTClient()
-                yield from sub_client.connect('mqtt://localhost', cleansession=False)
+                yield from sub_client.connect('mqtt://127.0.0.1', cleansession=False)
                 ret = yield from sub_client.subscribe([('/qos0', QOS_0), ('/qos1', QOS_1), ('/qos2', QOS_2)])
                 self.assertEqual(ret, [QOS_0, QOS_1, QOS_2])
                 yield from sub_client.disconnect()
@@ -716,7 +716,7 @@ class BrokerTest(unittest.TestCase):
     @asyncio.coroutine
     def _client_publish(self, topic, data, qos, retain=False):
         pub_client = MQTTClient()
-        ret = yield from pub_client.connect('mqtt://localhost/')
+        ret = yield from pub_client.connect('mqtt://127.0.0.1/')
         self.assertEqual(ret, 0)
         ret = yield from pub_client.publish(topic, data, qos, retain)
         yield from pub_client.disconnect()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -17,17 +17,17 @@ broker_config = {
     'listeners': {
         'default': {
             'type': 'tcp',
-            'bind': 'localhost:1883',
+            'bind': '127.0.0.1:1883',
             'max_connections': 10
         },
         'ws': {
             'type': 'ws',
-            'bind': 'localhost:8080',
+            'bind': '127.0.0.1:8080',
             'max_connections': 10
         },
         'wss': {
             'type': 'ws',
-            'bind': 'localhost:8081',
+            'bind': '127.0.0.1:8081',
             'max_connections': 10
         },
     },
@@ -87,7 +87,7 @@ class MQTTClientTest(unittest.TestCase):
             try:
                 config = {'auto_reconnect': False}
                 client = MQTTClient(config=config)
-                yield from client.connect('mqtt://localhost/')
+                yield from client.connect('mqtt://127.0.0.1/')
             except ConnectException as e:
                 future.set_result(True)
 
@@ -103,7 +103,7 @@ class MQTTClientTest(unittest.TestCase):
                 broker = Broker(broker_config, plugin_namespace="hbmqtt.test.plugins")
                 yield from broker.start()
                 client = MQTTClient()
-                yield from client.connect('ws://localhost:8080/')
+                yield from client.connect('ws://127.0.0.1:8080/')
                 self.assertIsNotNone(client.session)
                 yield from client.disconnect()
                 yield from broker.shutdown()
@@ -124,7 +124,7 @@ class MQTTClientTest(unittest.TestCase):
                 yield from broker.start()
                 client = MQTTClient()
                 ca = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'mosquitto.org.crt')
-                yield from client.connect('ws://localhost:8081/', cafile=ca)
+                yield from client.connect('ws://127.0.0.1:8081/', cafile=ca)
                 self.assertIsNotNone(client.session)
                 yield from client.disconnect()
                 yield from broker.shutdown()
@@ -144,7 +144,7 @@ class MQTTClientTest(unittest.TestCase):
                 broker = Broker(broker_config, plugin_namespace="hbmqtt.test.plugins")
                 yield from broker.start()
                 client = MQTTClient()
-                yield from client.connect('mqtt://localhost/')
+                yield from client.connect('mqtt://127.0.0.1/')
                 self.assertIsNotNone(client.session)
                 yield from client.ping()
                 yield from client.disconnect()
@@ -165,7 +165,7 @@ class MQTTClientTest(unittest.TestCase):
                 broker = Broker(broker_config, plugin_namespace="hbmqtt.test.plugins")
                 yield from broker.start()
                 client = MQTTClient()
-                yield from client.connect('mqtt://localhost/')
+                yield from client.connect('mqtt://127.0.0.1/')
                 self.assertIsNotNone(client.session)
                 ret = yield from client.subscribe([
                     ('$SYS/broker/uptime', QOS_0),
@@ -193,7 +193,7 @@ class MQTTClientTest(unittest.TestCase):
                 broker = Broker(broker_config, plugin_namespace="hbmqtt.test.plugins")
                 yield from broker.start()
                 client = MQTTClient()
-                yield from client.connect('mqtt://localhost/')
+                yield from client.connect('mqtt://127.0.0.1/')
                 self.assertIsNotNone(client.session)
                 ret = yield from client.subscribe([
                     ('$SYS/broker/uptime', QOS_0),
@@ -220,14 +220,14 @@ class MQTTClientTest(unittest.TestCase):
                 broker = Broker(broker_config, plugin_namespace="hbmqtt.test.plugins")
                 yield from broker.start()
                 client = MQTTClient()
-                yield from client.connect('mqtt://localhost/')
+                yield from client.connect('mqtt://127.0.0.1/')
                 self.assertIsNotNone(client.session)
                 ret = yield from client.subscribe([
                     ('test_topic', QOS_0),
                 ])
                 self.assertEqual(ret[0], QOS_0)
                 client_pub = MQTTClient()
-                yield from client_pub.connect('mqtt://localhost/')
+                yield from client_pub.connect('mqtt://127.0.0.1/')
                 yield from client_pub.publish('test_topic', data, QOS_0)
                 yield from client_pub.disconnect()
                 message = yield from client.deliver_message()
@@ -253,7 +253,7 @@ class MQTTClientTest(unittest.TestCase):
                 broker = Broker(broker_config, plugin_namespace="hbmqtt.test.plugins")
                 yield from broker.start()
                 client = MQTTClient()
-                yield from client.connect('mqtt://localhost/')
+                yield from client.connect('mqtt://127.0.0.1/')
                 self.assertIsNotNone(client.session)
                 ret = yield from client.subscribe([
                     ('test_topic', QOS_0),


### PR DESCRIPTION
By adding a additional variable 'client_id_is_random' the Test 'test_client_connect_clean_session_false' is fixed.  This variable allows to notice if a client_id is generated by the broker( It is allowed for clients to connects with no or empty client_id). 
In this case a it is not possible for clients to use old sessions and the broker disallows a connection. (He can't identify old sessions based on the random client_id)