### PR TITLE
TLS connections can be established by default with system certificate…

### DIFF
--- a/hbmqtt/client.py
+++ b/hbmqtt/client.py
@@ -364,9 +364,6 @@ class MQTTClient:
         self._handler = ClientProtocolHandler(self.plugins_manager, loop=self._loop)
 
         if secure:
-            if self.session.cafile is None or self.session.cafile == '':
-                self.logger.warning("TLS connection can't be estabilshed, no certificate file (.cert) given")
-                raise ClientException("TLS connection can't be estabilshed, no certificate file (.cert) given")
             sc = ssl.create_default_context(
                 ssl.Purpose.SERVER_AUTH,
                 cafile=self.session.cafile,


### PR DESCRIPTION
…s to publish domains (for example to 'mqtts://iot.eclipse.org') - the client only requires cafiles if the broker provides self signed certificates

The fix removes the exception thrown through missing cafiles.