### PR TITLE
Re-raise exception from deliver_task in MQTTClient.deliver_message().

### DIFF
--- a/hbmqtt/client.py
+++ b/hbmqtt/client.py
@@ -331,6 +331,9 @@ class MQTTClient:
         self.logger.debug("Waiting message delivery")
         done, pending = yield from asyncio.wait([deliver_task], loop=self._loop, return_when=asyncio.FIRST_EXCEPTION, timeout=timeout)
         if deliver_task in done:
+            if deliver_task.exception() is not None:
+                # deliver_task raised an exception, pass it on to our caller
+                raise deliver_task.exception()
             self.client_tasks.pop()
             return deliver_task.result()
         else:


### PR DESCRIPTION
`deliver_task` will raise a `ClientException` to signal a connection loss. Passing it on to the caller instead of silently ignoring it lets the caller handle the connection loss. Exiting the function early also avoids an `IndexError` when trying to pop from `client_tasks`.

Fixes #106