### PR TITLE
Correctly handle CONNECT with zero-length client_id

### DIFF
--- a/hbmqtt/broker.py
+++ b/hbmqtt/broker.py
@@ -370,7 +370,7 @@ class Broker:
 
         if client_session.clean_session:
             # Delete existing session and create a new one
-            if client_session.client_id is not None:
+            if client_session.client_id is not None and client_session.client_id != "":
                 self.delete_session(client_session.client_id)
             else:
                 client_session.client_id = gen_client_id()


### PR DESCRIPTION
Zero-length client_ids in CONNECT packets show up in the payload as empty strings, not None.
The broker should handle these correctly by generating its own client id as per the MQTT spec.

(This was causing some problems in Home Assistant, esp. when working with the Eclipse Paho python client, which defaults to an empty client_id.)