### PR TITLE
Client authentication error fixed

### DIFF
--- a/hbmqtt/broker.py
+++ b/hbmqtt/broker.py
@@ -393,6 +393,7 @@ class Broker:
         authenticated = yield from self.authenticate(client_session, self.listeners_config[listener_name])
         if not authenticated:
             yield from writer.close()
+            server.release_connection()  # Delete client from connections list
             return
 
         while True:


### PR DESCRIPTION
With this little change, when a client is not able to authenticate, the connection will be deleted from the list of connection. In that way, it will not occupy one connection, in case the number of maximum connections is very low.