### PR TITLE
Added topic filtering Plugin

### DIFF
--- a/hbmqtt/plugins/topic_checking.py
+++ b/hbmqtt/plugins/topic_checking.py
@@ -1,0 +1,37 @@
+import asyncio
+
+
+class BaseTopicPlugin:
+    def __init__(self, context):
+        self.context = context
+        try:
+            self.topic_config = self.context.config['topic-check']
+        except KeyError:
+            self.context.logger.warning("'topic-check' section not found in context configuration")
+
+    def topic_filtering(self, *args, **kwargs):
+        if not self.topic_config:
+            # auth config section not found
+            self.context.logger.warning("'auth' section not found in context configuration")
+            return False
+        return True
+
+
+class TopicTabooPlugin(BaseTopicPlugin):
+    def __init__(self, context):
+        super().__init__(context)
+        self._taboo = ['prohibited', 'top-secret', 'data/classified']
+
+    @asyncio.coroutine
+    def topic_filtering(self, *args, **kwargs):
+        filter_result = super().topic_filtering(*args, **kwargs)
+        if filter_result:
+            session = kwargs.get('session', None)
+            topic = kwargs.get('topic', None)
+            if session.username and topic:
+                if session.username != 'admin' and topic in self._taboo:
+                    return False
+                return True
+            else:
+                return False
+        return filter_result

--- a/samples/broker_taboo.py
+++ b/samples/broker_taboo.py
@@ -1,0 +1,49 @@
+import logging
+import asyncio
+import os
+from hbmqtt.broker import Broker
+
+logger = logging.getLogger(__name__)
+
+config = {
+    'listeners': {
+        'default': {
+            'type': 'tcp',
+            'bind': '0.0.0.0:1883',
+        },
+        'ws-mqtt': {
+            'bind': '127.0.0.1:8080',
+            'type': 'ws',
+            'max_connections': 10,
+        },
+    },
+    'sys_interval': 10,
+    'auth': {
+        'allow-anonymous': True,
+        'password-file': os.path.join(os.path.dirname(os.path.realpath(__file__)), "passwd"),
+        'plugins': [
+            'auth_file', 'auth_anonymous'
+        ]
+
+    },
+    'topic-check': {
+        'enabled': True,
+        'plugins': [
+            'topic_taboo'
+        ]
+    }
+}
+
+broker = Broker(config)
+
+
+@asyncio.coroutine
+def test_coro():
+    yield from broker.start()
+
+
+if __name__ == '__main__':
+    formatter = "[%(asctime)s] :: %(levelname)s :: %(name)s :: %(message)s"
+    logging.basicConfig(level=logging.INFO, format=formatter)
+    asyncio.get_event_loop().run_until_complete(test_coro())
+    asyncio.get_event_loop().run_forever()

--- a/samples/client_publish_taboo.py
+++ b/samples/client_publish_taboo.py
@@ -1,0 +1,33 @@
+import logging
+import asyncio
+
+from hbmqtt.client import MQTTClient, ConnectException
+
+
+#
+# This sample shows how to publish messages to broker using different QOS
+# Debug outputs shows the message flows
+#
+
+logger = logging.getLogger(__name__)
+
+
+@asyncio.coroutine
+def test_coro():
+    try:
+        C = MQTTClient()
+        yield from C.connect('mqtt://0.0.0.0:1883')
+        yield from C.publish('data/classified', b'TOP SECRET', qos=0x01)
+        yield from C.publish('data/memes', b'REAL FUN', qos=0x01)
+        logger.info("messages published")
+        yield from C.disconnect()
+    except ConnectException as ce:
+        logger.error("Connection failed: %s" % ce)
+        asyncio.get_event_loop().stop()
+
+
+if __name__ == '__main__':
+    formatter = "[%(asctime)s] %(name)s {%(filename)s:%(lineno)d} %(levelname)s - %(message)s"
+    formatter = "%(message)s"
+    logging.basicConfig(level=logging.DEBUG, format=formatter)
+    asyncio.get_event_loop().run_until_complete(test_coro())

--- a/samples/client_subscribe_taboo.py
+++ b/samples/client_subscribe_taboo.py
@@ -1,0 +1,42 @@
+import logging
+import asyncio
+
+from hbmqtt.client import MQTTClient, ClientException
+from hbmqtt.mqtt.constants import QOS_1
+
+
+#
+# This sample shows how to subscbribe a topic and receive data from incoming messages
+# It subscribes to '$SYS/broker/uptime' topic and displays the first ten values returned
+# by the broker.
+#
+
+logger = logging.getLogger(__name__)
+
+
+@asyncio.coroutine
+def uptime_coro():
+    C = MQTTClient()
+    yield from C.connect('mqtt://test:test@0.0.0.0:1883')
+    # Subscribe to '$SYS/broker/uptime' with QOS=1
+    yield from C.subscribe([
+        ('data/memes', QOS_1),  # Topic allowed
+        ('data/classified', QOS_1),  # Topic forbidden
+    ])
+    logger.info("Subscribed")
+    try:
+        for i in range(1, 100):
+            message = yield from C.deliver_message()
+            packet = message.publish_packet
+            print("%d: %s => %s" % (i, packet.variable_header.topic_name, str(packet.payload.data)))
+        yield from C.unsubscribe(['$SYS/broker/uptime', '$SYS/broker/load/#'])
+        logger.info("UnSubscribed")
+        yield from C.disconnect()
+    except ClientException as ce:
+        logger.error("Client exception: %s" % ce)
+
+
+if __name__ == '__main__':
+    formatter = "[%(asctime)s] {%(filename)s:%(lineno)d} %(levelname)s - %(message)s"
+    logging.basicConfig(level=logging.INFO, format=formatter)
+    asyncio.get_event_loop().run_until_complete(uptime_coro())

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
             'packet_logger_plugin = hbmqtt.plugins.logging:PacketLoggerPlugin',
             'auth_anonymous = hbmqtt.plugins.authentication:AnonymousAuthPlugin',
             'auth_file = hbmqtt.plugins.authentication:FileAuthPlugin',
+            'topic_taboo = hbmqtt.plugins.topic_checking:TopicTabooPlugin',
             'broker_sys = hbmqtt.plugins.sys.broker:BrokerSysPlugin',
         ],
         'hbmqtt.client.plugins': [


### PR DESCRIPTION
I have developed a new version of HBMQTT which supports topic filtering. This is: you can define a topic filtering plugin in order to grant or deny subscriptions to certain topics, depending on the policy you want.
For that, I have created the `hbmqtt/plugins/topic_checking.py` file, where I developed a very silly topic filtering policy: If you want to subscribe to `prohibited`, `top-secret` or `data/classified` topics, your username must be `admin`. Otherwise, you will not be subscribed. You may take this example as a template for designing your own topic policy.
# How to try it
After downloading this fork, execute the following python commands on the hbmqtt directory:
```
python3 setup.py build
python3 setup.py install
```
You can notice that this commit also adds a line in this script: This is necessary for the namespace to being able to detect the new plugin.

After that, you will execute three processes:
- `python3 samples/broker_taboo.py` 
This starts an MQTT broker with topic_taboo plugin enabled. This can be configured via the configuration parameter of the broker:
```
config = {
    'listeners': {
        'default': {
            'type': 'tcp',
            'bind': '0.0.0.0:1883',
        },
        'ws-mqtt': {
            'bind': '127.0.0.1:8080',
            'type': 'ws',
            'max_connections': 10,
        },
    },
    'sys_interval': 10,
    'auth': {
        'allow-anonymous': True,
        'password-file': os.path.join(os.path.dirname(os.path.realpath(__file__)), "passwd"),
        'plugins': [
            'auth_file', 'auth_anonymous'
        ]

    },
    'topic-check': {
        'enabled': True,
        'plugins': [
            'topic_taboo'
        ]
    }
}
```

- `python3 samples/client_subscribe_taboo.py`
This starts an MQTT client that will try to subscribe to a valid topic and a forbidden topic

- `python3 samples/client_publish_taboo.py`
This starts an MQTT client that will publish two messages in the valid and the forbidden topic.
The console of the client subscribed will only receive the valid message.