### PR TITLE
Pass in loop to PluginManager

### DIFF
--- a/hbmqtt/client.py
+++ b/hbmqtt/client.py
@@ -110,7 +110,7 @@ class MQTTClient:
         # Init plugins manager
         context = ClientContext()
         context.config = self.config
-        self.plugins_manager = PluginManager('hbmqtt.client.plugins', context)
+        self.plugins_manager = PluginManager('hbmqtt.client.plugins', context, loop=self._loop)
         self.client_tasks = deque()
 
     @asyncio.coroutine


### PR DESCRIPTION
If `loop` is passed to `MQTTClient`, previously it was not passed down
to `PluginManager`, which could potentially grab a different loop from
`asyncio.get_event_loop()`, resulting in a separate event loop being
created or wrong one being used. Now the `loop` argument is passed down
as expected.