### PR TITLE
In support of websockets 5.0

### DIFF
--- a/hbmqtt/client.py
+++ b/hbmqtt/client.py
@@ -18,7 +18,7 @@ from hbmqtt.mqtt.protocol.handler import ProtocolHandlerException
 from hbmqtt.mqtt.constants import QOS_0, QOS_1, QOS_2
 import websockets
 from websockets.uri import InvalidURI
-from websockets.handshake import InvalidHandshake
+from websockets.exceptions import InvalidHandshake
 from collections import deque
 import sys
 if sys.version_info < (3, 5):


### PR DESCRIPTION
Import InvalidHandshake from 'websockets.exceptions' not 'websockets.handshake', since websockets 5.0 no longer provides that alias.