### PR TITLE
Nightly build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,15 @@
 dist: trusty
 sudo: false
 language: python
+
 python:
   - "3.4"
   - "3.5"
   - "3.6"
+
 install:
-  - pip install tox-travis
-  - pip install coveralls
+  - pip install coveralls tox-travis
 script:
   - tox
-after_success: coveralls
+after_success:
+  - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "nightly"
+matrix:
+  allow_failures:
+    - python: "nightly"
 
 install:
   - pip install coveralls tox-travis


### PR DESCRIPTION
Reenable the nightly build, but use Travis' support for jobs that are allowed to fail without failing the entire build.