### PR TITLE
Only setting session username/password if it is not already set. 

### DIFF
--- a/hbmqtt/client.py
+++ b/hbmqtt/client.py
@@ -349,8 +349,8 @@ class MQTTClient:
         uri_attributes = urlparse(self.session.broker_uri)
         scheme = uri_attributes.scheme
         secure = True if scheme in ('mqtts', 'wss') else False
-        self.session.username = uri_attributes.username
-        self.session.password = uri_attributes.password
+        self.session.username = self.session.username if self.session.username else uri_attributes.username
+        self.session.password = self.session.password if self.session.password else uri_attributes.password
         self.session.remote_address = uri_attributes.hostname
         self.session.remote_port = uri_attributes.port
         if scheme in ('mqtt', 'mqtts') and not self.session.remote_port:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -115,6 +115,31 @@ class MQTTClientTest(unittest.TestCase):
         self.loop.run_until_complete(test_coro())
         if future.exception():
             raise future.exception()
+            raise future.exception()
+
+    def test_reconnect_ws_retain_username_password(self):
+        @asyncio.coroutine
+        def test_coro():
+            try:
+                broker = Broker(broker_config, plugin_namespace="hbmqtt.test.plugins")
+                yield from broker.start()
+                client = MQTTClient()
+                yield from client.connect('ws://fred:password@127.0.0.1:8080/')
+                self.assertIsNotNone(client.session)
+                yield from client.disconnect()
+                yield from client.reconnect()
+
+                self.assertIsNotNone(client.session.username)
+                self.assertIsNotNone(client.session.password)
+                yield from broker.shutdown()
+                future.set_result(True)
+            except Exception as ae:
+                future.set_exception(ae)
+
+        future = asyncio.Future(loop=self.loop)
+        self.loop.run_until_complete(test_coro())
+        if future.exception():
+            raise future.exception()
 
     def test_connect_ws_secure(self):
         @asyncio.coroutine


### PR DESCRIPTION
Currently if the broker_url contains username/password for `ws` and `wss`, the username and password are saved to `session.username` and `session.password`  from parsing the broker_url. 

However, the  the session.broker_uri is re-constructed for `ws` and `wss` and loses the username/password from the original broker_url. So on reconnect(), it'd attempt to connect to the broker without username/password making it fail.

This change is to make sure we don't override `session.username` and `session.password` if they already has values so that the reconnect() works as expected.