### PR TITLE
Add option for infitie reconnecting.

### DIFF
--- a/docs/references/hbmqtt_pub.rst
+++ b/docs/references/hbmqtt_pub.rst
@@ -61,7 +61,7 @@ If ``-c`` argument is given, ``hbmqtt_pub`` will read specific MQTT settings for
 * ``default_qos`` : Default QoS for messages published. Defaults to 0.
 * ``default_retain`` : Default retain value to messages published. Defaults to ``false``.
 * ``auto_reconnect`` : Enable or disable auto-reconnect if connectection with the broker is interrupted. Defaults to ``false``.
-* ``reconnect_retries`` : Maximum reconnection retries. Defaults to ``2``.
+* ``reconnect_retries`` : Maximum reconnection retries. Defaults to ``2``. Negative value will cause client to reconnect infinietly.
 * ``reconnect_max_interval`` : Maximum interval between 2 connection retry. Defaults to ``10``.
 
 

--- a/docs/references/hbmqtt_sub.rst
+++ b/docs/references/hbmqtt_sub.rst
@@ -54,7 +54,7 @@ If ``-c`` argument is given, ``hbmqtt_sub`` will read specific MQTT settings for
 * ``default_qos`` : Default QoS for messages published. Defaults to 0.
 * ``default_retain`` : Default retain value to messages published. Defaults to ``false``.
 * ``auto_reconnect`` : Enable or disable auto-reconnect if connectection with the broker is interrupted. Defaults to ``false``.
-* ``reconnect_retries`` : Maximum reconnection retries. Defaults to ``2``.
+* ``reconnect_retries`` : Maximum reconnection retries. Defaults to ``2``. Negative value will cause client to reconnect infinietly.
 * ``reconnect_max_interval`` : Maximum interval between 2 connection retry. Defaults to ``10``.
 
 

--- a/docs/references/mqttclient.rst
+++ b/docs/references/mqttclient.rst
@@ -165,8 +165,7 @@ The :class:`~hbmqtt.client.MQTTClient` ``__init__`` method accepts a ``config`` 
 * ``default_retain``: Default retain (``False``) used by :meth:`~hbmqtt.client.MQTTClient.publish` if ``qos`` argument is not given.,
 * ``auto_reconnect``: enable or disable auto-reconnect feature (defaults to ``True``).
 * ``reconnect_max_interval``: maximum interval (in seconds) to wait before two connection retries (defaults to ``10``).
-* ``reconnect_retries``: maximum number of connect retries (defaults to ``2``).
-
+* ``reconnect_retries``: maximum number of connect retries (defaults to ``2``). Negative value will cause client to reconnect infinietly.
 Default QoS and default retain can also be overriden by adding a ``topics`` with may contain QoS and retain values for specific topics. See the following example:
 
 .. code-block:: python

--- a/hbmqtt/client.py
+++ b/hbmqtt/client.py
@@ -205,7 +205,7 @@ class MQTTClient:
                 return (yield from self._do_connect())
             except BaseException as e:
                 self.logger.warning("Reconnection attempt failed: %r" % e)
-                if nb_attempt > reconnect_retries:
+                if reconnect_retries >= 0 and nb_attempt > reconnect_retries:
                     self.logger.error("Maximum number of connection attempts reached. Reconnection aborted")
                     raise ConnectException("Too many connection attempts failed")
                 exp = 2 ** nb_attempt


### PR DESCRIPTION
It simplifies reconnection logic. In case of long running services which publish data to server,
there is need to reconnect anyway. When reconnect_retries elapses, then reconnection have to be
done manually. Carrying about it inside coroutine which publishing data introduces complexity.
