### PR TITLE
hbmqtt.client: fix a Task leak

### DIFF
--- a/hbmqtt/client.py
+++ b/hbmqtt/client.py
@@ -66,7 +66,9 @@ def mqtt_connected(func):
     def wrapper(self, *args, **kwargs):
         if not self._connected_state.is_set():
             base_logger.warning("Client not connected, waiting for it")
-            yield from asyncio.wait([self._connected_state.wait(), self._no_more_connections.wait()], return_when=asyncio.FIRST_COMPLETED)
+            _, pending = yield from asyncio.wait([self._connected_state.wait(), self._no_more_connections.wait()], return_when=asyncio.FIRST_COMPLETED)
+            for t in pending:
+                t.cancel()
             if self._no_more_connections.is_set():
                 raise ClientException("Will not reconnect")
         return (yield from func(self, *args, **kwargs))


### PR DESCRIPTION
We should cleanup all pending events.