### PR TITLE
fix PyYAML warning on call of `yaml.load(…)`

### DIFF
--- a/hbmqtt/utils.py
+++ b/hbmqtt/utils.py
@@ -48,7 +48,7 @@ def read_yaml_config(config_file):
     config = None
     try:
         with open(config_file, 'r') as stream:
-            config = yaml.load(stream)
+            config = yaml.full_load(stream) if hasattr(yaml, 'full_load') else yaml.load(stream)
     except yaml.YAMLError as exc:
         logger.error("Invalid config_file %s: %s" % (config_file, exc))
     return config


### PR DESCRIPTION
Since PyYAML v5.1 a warning on deprecation is printed:

> YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated,
> as the default Loader is unsafe. Please read https://msg.pyyaml.org/load
> for full details.

Use the `FullLoader`s suggared variant `yaml.full_load` according to the
documentation [1] if it's present. Then it's assumed that PyYAML >= v5.1 is
used.

[1] https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation#how-to-disable-the-warning