### PR TITLE
Doing topic checking also in publish requests

### DIFF
--- a/hbmqtt/broker.py
+++ b/hbmqtt/broker.py
@@ -440,8 +440,7 @@ class Broker:
                                 client_session,
                                 client_session.will_topic,
                                 client_session.will_message,
-                                client_session.will_qos
-                                )
+                                client_session.will_qos)
                             if client_session.will_retain:
                                 self.retain_message(client_session,
                                                     client_session.will_topic,
@@ -599,7 +598,6 @@ class Broker:
         return topic_result
 
     def retain_message(self, source_session, topic_name, data, qos=None):
-        print("RETAIN M")
         if data is not None and data != b'':
             # If retained flag set, store the message for further subscriptions
             self.logger.debug("Retaining message on topic %s" % topic_name)
@@ -727,9 +725,6 @@ class Broker:
             if running_tasks:
                 yield from asyncio.wait(running_tasks, loop=self._loop)
 
-
-
-
     @asyncio.coroutine
     def _broadcast_message_acl(self, session, topic, data, force_qos=None):
         permitted = yield from self.topic_filtering(session, topic=topic)
@@ -737,12 +732,8 @@ class Broker:
         if permitted:
             yield from self._broadcast_message(session, topic, data, force_qos)
 
-
     @asyncio.coroutine
     def _broadcast_message(self, session, topic, data, force_qos=None):
-
-        print("data"+str(data))
-
         broadcast = {
             'session': session,
             'topic': topic,

--- a/hbmqtt/broker.py
+++ b/hbmqtt/broker.py
@@ -745,8 +745,6 @@ class Broker:
 
     @asyncio.coroutine
     def publish_session_retained_messages(self, session):
-        print("111111#############################")
-        print(session)
         self.logger.debug("Publishing %d messages retained for session %s" %
                           (session.retained_messages.qsize(), format_client_message(session=session))
                           )


### PR DESCRIPTION
I am working on a Django project which consists of a platform for remote control of IoT devices.
To integrate MQTT with the database I wrote a plugin in order to limit the access of users only to the topics to which they are authorized.
When doing some tests I realized that the topic checking is only performed in the sub requests, while in the pub requests anyone can publish in the topics reserved for other users.
Looking at the code in **brokery.py** I found that the method **topic_filtering() is called only in the sub requests**.
To solve this problem I added a function that calls the topic filtering in the pub requests that come from the users.