### PR TITLE
Also topic check on publish, as well as pass command argument to differentiate between publish and subscibe in plugin

### DIFF
--- a/hbmqtt/broker.py
+++ b/hbmqtt/broker.py
@@ -728,7 +728,6 @@ class Broker:
     @asyncio.coroutine
     def _broadcast_message_acl(self, session, topic, data, force_qos=None):
         permitted = yield from self.topic_filtering(session, topic=topic)
-
         if permitted:
             yield from self._broadcast_message(session, topic, data, force_qos)
 

--- a/hbmqtt/broker.py
+++ b/hbmqtt/broker.py
@@ -728,6 +728,7 @@ class Broker:
     @asyncio.coroutine
     def _broadcast_message_acl(self, session, topic, data, force_qos=None):
         permitted = yield from self.topic_filtering(session, topic=topic)
+        
         if permitted:
             yield from self._broadcast_message(session, topic, data, force_qos)
 

--- a/hbmqtt/broker.py
+++ b/hbmqtt/broker.py
@@ -440,8 +440,7 @@ class Broker:
                                 client_session,
                                 client_session.will_topic,
                                 client_session.will_message,
-                                client_session.will_qos
-                                )
+                                client_session.will_qos)
                             if client_session.will_retain:
                                 self.retain_message(client_session,
                                                     client_session.will_topic,
@@ -599,7 +598,6 @@ class Broker:
         return topic_result
 
     def retain_message(self, source_session, topic_name, data, qos=None):
-        print("RETAIN M")
         if data is not None and data != b'':
             # If retained flag set, store the message for further subscriptions
             self.logger.debug("Retaining message on topic %s" % topic_name)
@@ -727,9 +725,6 @@ class Broker:
             if running_tasks:
                 yield from asyncio.wait(running_tasks, loop=self._loop)
 
-
-
-
     @asyncio.coroutine
     def _broadcast_message_acl(self, session, topic, data, force_qos=None):
         permitted = yield from self.topic_filtering(session, topic=topic)
@@ -737,12 +732,8 @@ class Broker:
         if permitted:
             yield from self._broadcast_message(session, topic, data, force_qos)
 
-
     @asyncio.coroutine
     def _broadcast_message(self, session, topic, data, force_qos=None):
-
-        print("data"+str(data))
-
         broadcast = {
             'session': session,
             'topic': topic,

--- a/hbmqtt/broker.py
+++ b/hbmqtt/broker.py
@@ -745,8 +745,6 @@ class Broker:
 
     @asyncio.coroutine
     def publish_session_retained_messages(self, session):
-        print("111111#############################")
-        print(session)
         self.logger.debug("Publishing %d messages retained for session %s" %
                           (session.retained_messages.qsize(), format_client_message(session=session))
                           )


### PR DESCRIPTION
Built on top of #190.

When the plugin is run it should know whether it's a publish or subscribe command that's being processed, to allow for more advanced rules for example if a client should be allowed to subscribe to a topic but not publish. This is done by passing `command` in the kwargs of `topic_filtering`.

- `command == 1` - Publish
- `command == 0` - Subscribe