### PR TITLE
Misc fixes

### DIFF
--- a/hbmqtt/adapters.py
+++ b/hbmqtt/adapters.py
@@ -176,13 +176,13 @@ class StreamWriterAdapter(WriterAdapter):
     @asyncio.coroutine
     def close(self):
         if not self.is_closed:
+            self.is_closed = True # we first mark this closed so yields below don't cause races with waiting writes
             yield from self._writer.drain()
             if self._writer.can_write_eof():
                 self._writer.write_eof()
             self._writer.close()
             try: yield from self._writer.wait_closed() # py37+
             except AttributeError: pass
-            self.is_closed = True
 
 
 class BufferReader(ReaderAdapter):

--- a/hbmqtt/client.py
+++ b/hbmqtt/client.py
@@ -182,7 +182,7 @@ class MQTTClient:
         :return:
         """
         try:
-            while True:
+            while self.client_tasks:
                 task = self.client_tasks.pop()
                 task.cancel()
         except IndexError as err:
@@ -349,16 +349,16 @@ class MQTTClient:
         self.client_tasks.append(deliver_task)
         self.logger.debug("Waiting message delivery")
         done, pending = yield from asyncio.wait([deliver_task], loop=self._loop, return_when=asyncio.FIRST_EXCEPTION, timeout=timeout)
+        if self.client_tasks:
+            self.client_tasks.pop()
         if deliver_task in done:
             if deliver_task.exception() is not None:
                 # deliver_task raised an exception, pass it on to our caller
                 raise deliver_task.exception()
-            self.client_tasks.pop()
             return deliver_task.result()
         else:
             #timeout occured before message received
             deliver_task.cancel()
-            self.client_tasks.pop()
             raise asyncio.TimeoutError
 
     @asyncio.coroutine

--- a/hbmqtt/client.py
+++ b/hbmqtt/client.py
@@ -456,7 +456,7 @@ class MQTTClient:
             while self.client_tasks:
                 task = self.client_tasks.popleft()
                 if not task.done():
-                    task.set_exception(ClientException("Connection lost"))
+                    task.cancel()
 
         self.logger.debug("Watch broker disconnection")
         # Wait for disconnection from broker (like connection lost)

--- a/hbmqtt/codecs.py
+++ b/hbmqtt/codecs.py
@@ -49,7 +49,10 @@ def read_or_raise(reader, n=-1):
     :param n: number of bytes to read
     :return: bytes read
     """
-    data = yield from reader.read(n)
+    try:
+        data = yield from reader.read(n)
+    except (asyncio.IncompleteReadError, ConnectionResetError):
+        data = None
     if not data:
         raise NoDataException("No more data")
     return data

--- a/hbmqtt/codecs.py
+++ b/hbmqtt/codecs.py
@@ -51,7 +51,7 @@ def read_or_raise(reader, n=-1):
     """
     try:
         data = yield from reader.read(n)
-    except (asyncio.IncompleteReadError, ConnectionResetError):
+    except (asyncio.IncompleteReadError, ConnectionResetError, BrokenPipeError):
         data = None
     if not data:
         raise NoDataException("No more data")

--- a/hbmqtt/mqtt/protocol/handler.py
+++ b/hbmqtt/mqtt/protocol/handler.py
@@ -449,9 +449,8 @@ class ProtocolHandler:
                 self._keepalive_task = self._loop.call_later(self.keepalive_timeout, self.handle_write_timeout)
 
             yield from self.plugins_manager.fire_event(EVENT_MQTT_PACKET_SENT, packet=packet, session=self.session)
-        except ConnectionResetError as cre:
+        except (ConnectionResetError, BrokenPipeError):
             yield from self.handle_connection_closed()
-            raise
         except BaseException as e:
             self.logger.warning("Unhandled exception: %s" % e)
             raise

--- a/hbmqtt/mqtt/protocol/handler.py
+++ b/hbmqtt/mqtt/protocol/handler.py
@@ -451,6 +451,8 @@ class ProtocolHandler:
             yield from self.plugins_manager.fire_event(EVENT_MQTT_PACKET_SENT, packet=packet, session=self.session)
         except (ConnectionResetError, BrokenPipeError):
             yield from self.handle_connection_closed()
+        except asyncio.CancelledError:
+            raise
         except BaseException as e:
             self.logger.warning("Unhandled exception: %s" % e)
             raise

--- a/hbmqtt/mqtt/protocol/handler.py
+++ b/hbmqtt/mqtt/protocol/handler.py
@@ -417,7 +417,7 @@ class ProtocolHandler:
                         if task:
                             running_tasks.append(task)
                 else:
-                    self.logger.debug("%s No more data (EOF received), stopping reader coro" % self.session.client_id)
+                    self.logger.debug("No more data (EOF received), stopping reader coro")
                     break
             except MQTTException:
                 self.logger.debug("Message discarded")
@@ -425,10 +425,10 @@ class ProtocolHandler:
                 self.logger.debug("Task cancelled, reader loop ending")
                 break
             except asyncio.TimeoutError:
-                self.logger.debug("%s Input stream read timeout" % self.session.client_id)
+                self.logger.debug("Input stream read timeout")
                 self.handle_read_timeout()
             except NoDataException:
-                self.logger.debug("%s No data available" % self.session.client_id)
+                self.logger.debug("No data available")
             except BaseException as e:
                 self.logger.warning("%s Unhandled exception in reader coro: %r" % (type(self).__name__, e))
                 break
@@ -436,7 +436,7 @@ class ProtocolHandler:
             running_tasks.popleft().cancel()
         yield from self.handle_connection_closed()
         self._reader_stopped.set()
-        self.logger.debug("%s Reader coro stopped" % self.session.client_id)
+        self.logger.debug("Reader coro stopped")
         yield from self.stop()
 
     @asyncio.coroutine
@@ -457,6 +457,8 @@ class ProtocolHandler:
 
     @asyncio.coroutine
     def mqtt_deliver_next_message(self):
+        if not self._is_attached():
+            return None
         if self.logger.isEnabledFor(logging.DEBUG):
             self.logger.debug("%d message(s) available for delivery" % self.session.delivered_message_queue.qsize())
         try:

--- a/hbmqtt/plugins/manager.py
+++ b/hbmqtt/plugins/manager.py
@@ -149,7 +149,8 @@ class PluginManager:
         if wait:
             if tasks:
                 yield from asyncio.wait(tasks, loop=self._loop)
-        self.logger.debug("Plugins len(_fired_events)=%d" % (len(self._fired_events)))
+        if self.logger.isEnabledFor(logging.DEBUG):
+            self.logger.debug("Plugins len(_fired_events)=%d" % (len(self._fired_events)))
 
     @asyncio.coroutine
     def map(self, coro, *args, **kwargs):


### PR DESCRIPTION
Critical correction for unlimited memory consumption building up retained messages for disconnected sessions where QOS is 0. I did not correct the rest of the retained message handling in this go 'round; e.g., messages should be uniquely retained by topic yet every single message is retained. Perhaps someone else will tackle this.

Critical bug fixes for client disconnect calling a deprecated asyncio API where set_exception is no longer supported on tasks. Changed to merely cancel incomplete tasks.

Critical crash fixes for log messages that were invalid due to a race condition when a session handler is detached which forces session references to None.

Added several if self.logger.isEnabledFor(logging.DEBUG): wrappers to improve performance a tiny bit. More could be done here.