### PR TITLE
Fix topic filter matching

### DIFF
--- a/hbmqtt/adapters.py
+++ b/hbmqtt/adapters.py
@@ -121,7 +121,7 @@ class WebSocketsWriter(WriterAdapter):
         self._stream = io.BytesIO(b'')
 
     def get_peer_info(self):
-        return self._protocol.remote_address
+        return self._protocol.remote_address[:2]
 
     @asyncio.coroutine
     def close(self):

--- a/hbmqtt/broker.py
+++ b/hbmqtt/broker.py
@@ -683,8 +683,8 @@ class Broker:
             return a_filter == topic
         else:
             # else use regex
-            match_pattern = re.compile(a_filter.replace('#', '.*').replace('$', '\$').replace('+', '[/\$\s\w\d]+'))
-            return match_pattern.match(topic)
+            match_pattern = re.compile(re.escape(a_filter).replace('\\#', '?.*').replace('\\+', '[^/]*').lstrip('?'))
+            return match_pattern.fullmatch(topic)
 
     @asyncio.coroutine
     def _broadcast_loop(self):

--- a/hbmqtt/client.py
+++ b/hbmqtt/client.py
@@ -471,7 +471,7 @@ class MQTTClient:
         self._connected_state.clear()
 
         # stop an clean handler
-        #yield from self._handler.stop()
+        yield from self._handler.stop()
         self._handler.detach()
         self.session.transitions.disconnect()
 

--- a/hbmqtt/client.py
+++ b/hbmqtt/client.py
@@ -147,6 +147,8 @@ class MQTTClient:
 
         try:
             return (yield from self._do_connect())
+        except asyncio.CancelledError:
+            raise
         except BaseException as be:
             self.logger.warning("Connection failed: %r" % be)
             auto_reconnect = self.config.get('auto_reconnect', False)
@@ -218,6 +220,8 @@ class MQTTClient:
             try:
                 self.logger.debug("Reconnect attempt %d ..." % nb_attempt)
                 return (yield from self._do_connect())
+            except asyncio.CancelledError:
+                raise
             except BaseException as e:
                 self.logger.warning("Reconnection attempt failed: %r" % e)
                 if reconnect_retries >= 0 and nb_attempt > reconnect_retries:

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -565,6 +565,92 @@ class BrokerTest(unittest.TestCase):
             raise future.exception()
 
     @patch('hbmqtt.broker.PluginManager')
+    def test_client_subscribe_publish_multi_level_wildcard(self, MockPluginManager):
+        @asyncio.coroutine
+        def test_coro():
+            try:
+                broker = Broker(test_config, plugin_namespace="hbmqtt.test.plugins")
+                yield from broker.start()
+                self.assertTrue(broker.transitions.is_started())
+                sub_client = MQTTClient()
+                yield from sub_client.connect('mqtt://127.0.0.1')
+                ret = yield from sub_client.subscribe([('sport/tennis/player1/#', QOS_0)])
+                self.assertEqual(ret, [QOS_0])
+
+                for bad_topic in [
+                    'sport/tennis',
+                    'sport/tennis/',
+                ]:
+                    yield from self._client_publish(bad_topic, b'data', QOS_0)
+                    with self.assertRaises(asyncio.TimeoutError, msg=bad_topic):
+                        yield from sub_client.deliver_message(timeout=2)
+
+                for good_topic in [
+                    'sport/tennis/player1',
+                    'sport/tennis/player1/',
+                    'sport/tennis/player1/ranking',
+                    'sport/tennis/player1/score/wimbledon',
+                ]:
+                    yield from self._client_publish(good_topic, b'data', QOS_0)
+                    yield from sub_client.deliver_message(timeout=2)
+
+                yield from sub_client.disconnect()
+                yield from asyncio.sleep(0.1)
+                yield from broker.shutdown()
+                self.assertTrue(broker.transitions.is_stopped())
+                future.set_result(True)
+            except Exception as ae:
+                future.set_exception(ae)
+
+        future = asyncio.Future(loop=self.loop)
+        self.loop.run_until_complete(test_coro())
+        if future.exception():
+            raise future.exception()
+
+    @patch('hbmqtt.broker.PluginManager')
+    def test_client_subscribe_publish_single_level_wildcard(self, MockPluginManager):
+        @asyncio.coroutine
+        def test_coro():
+            try:
+                broker = Broker(test_config, plugin_namespace="hbmqtt.test.plugins")
+                yield from broker.start()
+                self.assertTrue(broker.transitions.is_started())
+                sub_client = MQTTClient()
+                yield from sub_client.connect('mqtt://127.0.0.1')
+                ret = yield from sub_client.subscribe([('sport/tennis/+', QOS_0)])
+                self.assertEqual(ret, [QOS_0])
+
+                for bad_topic in [
+                    'sport/tennis',
+                    'sport/tennis/player1/',
+                    'sport/tennis/player1/ranking',
+                ]:
+                    yield from self._client_publish(bad_topic, b'data', QOS_0)
+                    with self.assertRaises(asyncio.TimeoutError, msg=bad_topic):
+                        yield from sub_client.deliver_message(timeout=2)
+
+                for good_topic in [
+                    'sport/tennis/',
+                    'sport/tennis/player1',
+                    'sport/tennis/player2',
+                ]:
+                    yield from self._client_publish(good_topic, b'data', QOS_0)
+                    yield from sub_client.deliver_message(timeout=2)
+
+                yield from sub_client.disconnect()
+                yield from asyncio.sleep(0.1)
+                yield from broker.shutdown()
+                self.assertTrue(broker.transitions.is_stopped())
+                future.set_result(True)
+            except Exception as ae:
+                future.set_exception(ae)
+
+        future = asyncio.Future(loop=self.loop)
+        self.loop.run_until_complete(test_coro())
+        if future.exception():
+            raise future.exception()
+
+    @patch('hbmqtt.broker.PluginManager')
     def test_client_subscribe_invalid(self, MockPluginManager):
         @asyncio.coroutine
         def test_coro():
@@ -643,7 +729,7 @@ class BrokerTest(unittest.TestCase):
                 ret = yield from sub_client.subscribe([('+/monitor/Clients', QOS_0)])
                 self.assertEqual(ret, [QOS_0])
 
-                yield from self._client_publish('/test/monitor/Clients', b'data', QOS_0)
+                yield from self._client_publish('test/monitor/Clients', b'data', QOS_0)
                 message = yield from sub_client.deliver_message()
                 self.assertIsNotNone(message)
 


### PR DESCRIPTION
- re.escape() the whole filter string first to escape _all_ regex
  metacharacters in it, not just $. (# and + are both regex metacharacters,
  so their replace expressions now need a leading \\ to replace the
  escaping, too.)
- \# matches topics both with and without a trailing /, so the replace
  expressions adds a '?' before the '.*'. The .lstrip('?') at the end removes
  this in case the # was the first character in the filter.
- \+ should only match a single level, but it should _also_ match empty levels,
  so use '[^/]*' to replace it.
- Use Regex.fullmatch() to match against the whole topic string, not just
  its start.

Also add two unit tests to test this matching, and fix an incorrect match
against + in test_client_subscribe_publish_dollar_topic_2.

This fixes #44.