### PR TITLE
Replace formatted string with c-style

### DIFF
--- a/hbmqtt/broker.py
+++ b/hbmqtt/broker.py
@@ -725,7 +725,8 @@ class Broker:
                                     broadcast['session'], broadcast['topic'], broadcast['data'], qos)
                                 yield from target_session.retained_messages.put(retained_message)
                                 if self.logger.isEnabledFor(logging.DEBUG):
-                                    self.logger.debug(f'target_session.retained_messages={target_session.retained_messages.qsize()}')
+                                    self.logger.debug("target_session.retained_messages=%s" %
+                                                      target_session.retained_messages.qsize())
         except CancelledError:
             # Wait until current broadcasting tasks end
             if running_tasks:


### PR DESCRIPTION
f-strings have been introduced in python3.6. If hbmqtt should still comply py3.5 it needs to use classic c-style. However, I personally think it would be very reasonable to drop python3.5 support. What do you think @njouanin?