### PR TITLE
Switch build distro trusty->xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 sudo: false
 language: python
 


### PR DESCRIPTION
Apparently, the build pipeline fails on builds that succeeded before. Bumping distro version to a later release (`16.04`)