### PR TITLE
Added client support for self signed certificate on MQTT server

### DIFF
--- a/docs/references/mqttclient.rst
+++ b/docs/references/mqttclient.rst
@@ -164,6 +164,7 @@ The :class:`~hbmqtt.client.MQTTClient` ``__init__`` method accepts a ``config`` 
 * ``default_qos``: Default QoS (``0``) used by :meth:`~hbmqtt.client.MQTTClient.publish` if ``qos`` argument is not given.
 * ``default_retain``: Default retain (``False``) used by :meth:`~hbmqtt.client.MQTTClient.publish` if ``qos`` argument is not given.,
 * ``auto_reconnect``: enable or disable auto-reconnect feature (defaults to ``True``).
+* ``ca_certs``: a string path to the Certificate Authority certificate files that are to be treated as trusted by this client. If provided, the client will require the broker to have a certificate signed by the Certificate Authorities in ca_certs and will communicate using TLS, if not provided the client will use the system's Certificate Authorities.
 * ``reconnect_max_interval``: maximum interval (in seconds) to wait before two connection retries (defaults to ``10``).
 * ``reconnect_retries``: maximum number of connect retries (defaults to ``2``). Negative value will cause client to reconnect infinietly.
 Default QoS and default retain can also be overriden by adding a ``topics`` with may contain QoS and retain values for specific topics. See the following example:

--- a/hbmqtt/client.py
+++ b/hbmqtt/client.py
@@ -396,6 +396,8 @@ class MQTTClient:
                 sc.load_cert_chain(self.config['certfile'], self.config['keyfile'])
             if 'check_hostname' in self.config and isinstance(self.config['check_hostname'], bool):
                 sc.check_hostname = self.config['check_hostname']
+            if 'ca_certs' in self.config:
+                sc.load_verify_locations(self.config['ca_certs'])
             kwargs['ssl'] = sc
 
         try:


### PR DESCRIPTION
I'd like to use the mqtt client against a server with a self signed Certificate Authority. The proposed patch will add a new client configuration attribute defined as **ca_certs** for assigning a custom CA (instead of using the system ones) to the ssl context. The connection will be initiated only if the mqtt server's certificate chain resolved to any of the custom CAs.

For reference, see the implementation from patho-mqtt: https://github.com/eclipse/paho.mqtt.python/blob/225ab3757f6818ba85eb80564948d1c787190cba/src/paho/mqtt/client.py#L767