### PR TITLE
Update Websockets usage

### DIFF
--- a/hbmqtt/adapters.py
+++ b/hbmqtt/adapters.py
@@ -3,7 +3,7 @@
 # See the file license.txt for copying permission.
 import asyncio
 import io
-from websockets.protocol import WebSocketCommonProtocol
+from websockets.legacy.protocol import WebSocketCommonProtocol
 from websockets.exceptions import ConnectionClosed
 from asyncio import StreamReader, StreamWriter
 import logging


### PR DESCRIPTION
Websockets protocol.py file has been moved to the legacy folder, creating error for people who have this version.